### PR TITLE
fix: avoid cross-resource fs.write permission error on screenshot save

### DIFF
--- a/server.js
+++ b/server.js
@@ -35,15 +35,25 @@ try {
 			console.log(`DEBUG: Processing screenshot: ${filename}.png`);
 		}
 
+		// Note: we intentionally do NOT pass `fileName` to screenshot-basic.
+		// With a fileName set, screenshot-basic moves the staged upload into this
+		// resource's folder, which trips FiveM's cross-resource fs.write permission
+		// check on recent FXServer builds. Instead we request the screenshot as a
+		// base64 data URI and write it ourselves, since a resource is always allowed
+		// to write to its own folder.
 		exports['screenshot-basic'].requestClientScreenshot(
 			source,
 			{
-				fileName: fullFilePath,
 				encoding: 'png',
 				quality: 1.0,
 			},
-			async (err, fileName) => {
-				let image = await imagejs.Image.load(fileName);
+			async (err, data) => {
+				if (err) {
+					console.error(`Screenshot failed for ${filename}.png: ${err}`);
+					return;
+				}
+
+				let image = await imagejs.Image.load(data);
 
 				// Apply greenscreen removal
 				for (let x = 0; x < image.width; x++) {
@@ -97,7 +107,7 @@ try {
 					image.height = croppedImage.height;
 				}
 
-				image.save(fileName);
+				image.save(fullFilePath);
 			}
 		);
 	});


### PR DESCRIPTION
### What

Fixes the server-side save failing with a filesystem permission error on recent
FXServer builds:

```
[    c-scripting-node] Filesystem write permission check from 'screenshot-basic'
for permission fs.write on resource '.../resources/fivem-greenscreener/images/objects/2240524752.png'
- write not allowed
```

Closes #21.

### Why

`server.js` passes `fileName: fullFilePath` to `requestClientScreenshot`. With a
`fileName` set, screenshot-basic stages the upload in its own `.tmp` folder and
then **moves it into the greenscreener resource folder** via `mv()`
(`src/server/server.ts`, the `if (upload.fileName)` branch).

Recent FXServer builds enforce a per-resource filesystem ACL, so a write that
originates in `screenshot-basic` but targets another resource's folder is
blocked. The usual `add_filesystem_permission` line in `server.cfg` does not
reliably lift this for the cross-resource move.

### How

Don't pass `fileName`. When omitted, screenshot-basic returns the screenshot as
a base64 data URI (no cross-resource write). We load that, run the existing
greenscreen removal / crop, and save the final image into this resource's **own**
folder, which a resource is always allowed to write to. No `server.cfg`
permission line required. Also added an early bail-out + log if the screenshot
request errors.

### Testing

Tested locally on:

- **fivem-greenscreener:** v1.6.5
- **FXServer build:** b31550 (Windows)
- **txAdmin:** v8.1.1

`/screenshotobject`, `/screenshot` and `/customscreenshot` all save correctly to
`images/` with no permission errors and no `server.cfg` changes.
