### PR TITLE
Feat/clothes control panel

### DIFF
--- a/client.js
+++ b/client.js
@@ -1030,7 +1030,7 @@ async function runClothingJob(opts) {
 // Opens the panel: grabs NUI focus and hands the NUI the selectable components
 // (built from config so it always matches cameraSettings), then asks the server
 // which images already exist to populate the "skip" baseline.
-RegisterCommand('clothes', () => {
+RegisterCommand('customclothes', () => {
 	SetNuiFocus(true, true);
 	SendNUIMessage({
 		action: 'open',
@@ -1078,7 +1078,7 @@ registerNui('clothes:close', () => { SetNuiFocus(false, false); });
 setImmediate(() => {
 	emit('chat:addSuggestions', [
 		{
-			name: '/clothes',
+			name: '/customclothes',
 			help: 'open the clothing capture control panel (select components, gender, progress, ETA)',
 		},
 		{

--- a/client.js
+++ b/client.js
@@ -383,6 +383,7 @@ function createGreenScreenVehicle(vehicleHash, vehicleModel) {
 			}
 		}
 		const vehicle = CreateVehicle(vehicleHash, config.greenScreenVehiclePosition.x, config.greenScreenVehiclePosition.y, config.greenScreenVehiclePosition.z, 0, true, true);
+		SetVehicleDirtLevel(vehicle, 0);
 		if (vehicle === 0) {
 			clearTimeout(timeout);
 			resolve(null);

--- a/client.js
+++ b/client.js
@@ -15,6 +15,78 @@ if (config.useQBVehicles) {
 	QBCore = exports[config.coreResourceName].GetCoreObject();
 }
 
+// ===========================================================================
+//  /clothes control panel
+//  ---------------------------------------------------------------------------
+//  An optional NUI front-end for clothing/prop capture. It drives the same
+//  capture helpers used by the chat commands (takeScreenshotForComponent,
+//  LoadComponentVariation, ...) but adds: component/gender selection, a live
+//  progress bar with ETA, pause/resume/stop, and a "skip already captured"
+//  option that lets a long run be resumed simply by launching it again.
+//
+//  Flow: the `clothesJob` object below is the single source of truth for an
+//  in-flight run. NUI buttons flip its `paused` / `stopRequested` flags via
+//  NUI callbacks; the capture loop (runClothingJob) reads them cooperatively.
+// ===========================================================================
+const clothesJob = {
+	running: false,
+	paused: false,
+	stopRequested: false,
+	total: 0,
+	done: 0,
+	times: [], // rolling capture durations (ms), used to estimate the ETA
+};
+// PNG filenames already present in images/clothing, fetched from the server.
+// Used both to seed the initial progress count and to skip captures on resume.
+let lastExisting = new Set();
+
+// Builds the exact name used by takeScreenshotForComponent so the "skip already
+// captured" check matches what the server actually writes to disk.
+function clothingFileName(pedType, type, component, drawable, texture) {
+	return `${pedType}_${type == 'PROPS' ? 'prop_' : ''}${component}_${drawable}${texture ? `_${texture}` : ''}`;
+}
+
+// Cooperative pause: the capture loop awaits this before each item, so a run
+// can be held without busy-looping and resumes as soon as `paused` clears.
+async function waitWhilePaused() {
+	while (clothesJob.paused && !clothesJob.stopRequested) {
+		await Delay(150);
+	}
+}
+
+// Formats a seconds count as mm:ss (or h:mm:ss) for the ETA readout.
+function formatETA(seconds) {
+	if (!isFinite(seconds) || seconds < 0) return '--:--';
+	seconds = Math.round(seconds);
+	const h = Math.floor(seconds / 3600);
+	const m = Math.floor((seconds % 3600) / 60);
+	const s = seconds % 60;
+	const pad = (n) => String(n).padStart(2, '0');
+	return h > 0 ? `${h}:${pad(m)}:${pad(s)}` : `${pad(m)}:${pad(s)}`;
+}
+
+// Pushes the current progress snapshot to the NUI. ETA and rate are derived
+// from the rolling average of recent capture times so they reflect the current
+// speed rather than the whole-run average.
+function emitClothesProgress(label) {
+	const remaining = Math.max(0, clothesJob.total - clothesJob.done);
+	const avg = clothesJob.times.length
+		? clothesJob.times.reduce((a, b) => a + b, 0) / clothesJob.times.length
+		: 0;
+	const etaSec = avg ? (avg * remaining) / 1000 : Infinity;
+	const rate = avg ? 1000 / avg : 0;
+	SendNUIMessage({
+		action: 'progress',
+		done: clothesJob.done,
+		total: clothesJob.total,
+		percent: clothesJob.total ? Math.floor((clothesJob.done / clothesJob.total) * 100) : 0,
+		eta: formatETA(etaSec),
+		rate: rate.toFixed(2),
+		label: label || '',
+		paused: clothesJob.paused,
+	});
+}
+
 async function takeScreenshotForComponent(pedType, type, component, drawable, texture, cameraSettings) {
 	const cameraInfo = cameraSettings ? cameraSettings : config.cameraSettings[type][component];
 
@@ -56,7 +128,7 @@ async function takeScreenshotForComponent(pedType, type, component, drawable, te
 
 	SetEntityRotation(ped, camInfo.rotation.x, camInfo.rotation.y, camInfo.rotation.z, 2, false);
 
-	emitNet('takeScreenshot', `${pedType}_${type == 'PROPS' ? 'prop_' : ''}${component}_${drawable}${texture ? `_${texture}`: ''}`, 'clothing');
+	emitNet('takeScreenshot', clothingFileName(pedType, type, component, drawable, texture), 'clothing');
 	await Delay(2000);
 	return;
 }
@@ -213,8 +285,26 @@ function setWeatherTime() {
 	NetworkOverrideClockMillisecondsPerGameMinute(1000000);
 }
 
+// Hides the entire native HUD (radar, area/street/vehicle names, notifications,
+// wanted stars, etc.) every frame while capturing, so none of it gets baked into
+// a screenshot. HideHudAndRadarThisFrame is a "ThisFrame" native, hence the tick.
+let hudHideInterval = null;
+function startHudHide() {
+	if (hudHideInterval) return;
+	hudHideInterval = setInterval(() => {
+		HideHudAndRadarThisFrame();
+	}, 0);
+}
+function stopHudHide() {
+	if (hudHideInterval) {
+		clearInterval(hudHideInterval);
+		hudHideInterval = null;
+	}
+}
+
 function stopWeatherResource() {
 	if (config.debug) console.log(`DEBUG: Stopping Weather Resource`);
+	startHudHide(); // hide the whole native HUD so it doesn't appear in the screenshots
 	if ((GetResourceState('qb-weathersync') == 'started') || (GetResourceState('qbx_weathersync') == 'started')) {
 		TriggerEvent('qb-weathersync:client:DisableSync');
 		return true;
@@ -222,6 +312,7 @@ function stopWeatherResource() {
 		TriggerEvent('weathersync:toggleSync')
 		return true;
 	} else if (GetResourceState('esx_wsync') == 'started') {
+		stopHudHide(); // capture is aborting, restore the HUD
 		SendNUIMessage({
 			error: 'weathersync',
 		});
@@ -238,6 +329,7 @@ function stopWeatherResource() {
 
 function startWeatherResource() {
 	if (config.debug) console.log(`DEBUG: Starting Weather Resource again`);
+	stopHudHide(); // restore the HUD that was hidden for the capture
 	if ((GetResourceState('qb-weathersync') == 'started') || (GetResourceState('qbx_weathersync') == 'started')) {
 		TriggerEvent('qb-weathersync:client:EnableSync');
 	} else if (GetResourceState('weathersync') == 'started') {
@@ -291,7 +383,6 @@ function createGreenScreenVehicle(vehicleHash, vehicleModel) {
 			}
 		}
 		const vehicle = CreateVehicle(vehicleHash, config.greenScreenVehiclePosition.x, config.greenScreenVehiclePosition.y, config.greenScreenVehiclePosition.z, 0, true, true);
-		SetVehicleDirtLevel(vehicle, 0);
 		if (vehicle === 0) {
 			clearTimeout(timeout);
 			resolve(null);
@@ -339,6 +430,11 @@ RegisterCommand('screenshot', async (source, args) => {
 			FreezeEntityPosition(ped, true);
 			await Delay(50);
 			SetPlayerControl(playerId, false);
+
+			// Wait for the scene to stream in around the greenscreen before the first
+			// capture, otherwise the first screenshot can come out completely black.
+			await waitForSceneLoaded(ped);
+			await Delay(config.startupDelay || 1500);
 
 			interval = setInterval(() => {
 				ClearPedTasksImmediately(ped);
@@ -474,6 +570,11 @@ RegisterCommand('customscreenshot', async (source, args) => {
 			await Delay(50);
 			SetPlayerControl(playerId, false);
 
+			// Wait for the scene to stream in around the greenscreen before the first
+			// capture, otherwise the first screenshot can come out completely black.
+			await waitForSceneLoaded(ped);
+			await Delay(config.startupDelay || 1500);
+
 			ResetPedComponents();
 			await Delay(150);
 
@@ -607,6 +708,10 @@ RegisterCommand('screenshotobject', async (source, args) => {
 
 	await Delay(50);
 
+	// Wait for the scene to stream in before capturing (avoids a black image).
+	await waitForSceneLoaded(ped);
+	await Delay(config.startupDelay || 1500);
+
 	await takeScreenshotForObject(object, modelHash);
 
 
@@ -637,6 +742,10 @@ RegisterCommand('screenshotvehicle', async (source, args) => {
 	ClearAreaOfVehicles(config.greenScreenPosition.x, config.greenScreenPosition.y, config.greenScreenPosition.z, 10, false, false, false, false, false);
 
 	await Delay(100);
+
+	// Wait for the scene to stream in before capturing (avoids black images).
+	await waitForSceneLoaded(ped);
+	await Delay(config.startupDelay || 1500);
 
 	if (type === 'all') {
 		SendNUIMessage({
@@ -735,8 +844,243 @@ RegisterCommand('screenshotvehicle', async (source, args) => {
 
 
 
+// ---------------------------------------------------------------------------
+//  /clothes control panel: job engine + NUI wiring
+// ---------------------------------------------------------------------------
+
+// Switches the player ped to the requested freemode model and places/freezes it
+// on the greenscreen, mirroring the setup used by the /screenshot command.
+async function loadGenderModel(gender) {
+	const modelHash = gender === 'female' ? GetHashKey('mp_f_freemode_01') : GetHashKey('mp_m_freemode_01');
+	if (!IsModelValid(modelHash)) return null;
+	if (!HasModelLoaded(modelHash)) {
+		RequestModel(modelHash);
+		while (!HasModelLoaded(modelHash)) {
+			await Delay(100);
+		}
+	}
+	SetPlayerModel(playerId, modelHash);
+	await Delay(150);
+	SetModelAsNoLongerNeeded(modelHash);
+	await Delay(150);
+	ped = PlayerPedId();
+	SetEntityRotation(ped, config.greenScreenRotation.x, config.greenScreenRotation.y, config.greenScreenRotation.z, 0, false);
+	SetEntityCoordsNoOffset(ped, config.greenScreenPosition.x, config.greenScreenPosition.y, config.greenScreenPosition.z, false, false, false);
+	FreezeEntityPosition(ped, true);
+	await Delay(50);
+	SetPlayerControl(playerId, false);
+	return ped;
+}
+
+// Waits until the map has streamed in (collision loaded) around the ped, with a
+// timeout so it never hangs. Without this the first screenshot can come out black
+// because the scene around the greenscreen hasn't finished loading yet.
+async function waitForSceneLoaded(targetPed) {
+	const [x, y, z] = GetEntityCoords(targetPed, false);
+	const start = GetGameTimer();
+	while (!HasCollisionLoadedAroundEntity(targetPed) && GetGameTimer() - start < 5000) {
+		RequestCollisionAtCoord(x, y, z);
+		await Delay(100);
+	}
+}
+
+// Restores game state after a run finishes or is stopped: clears the task
+// loop, hands control back, drops cameras and re-enables the weather resource.
+function cleanupClothesJob() {
+	if (interval) clearInterval(interval);
+	SetPlayerControl(playerId, true);
+	if (ped) FreezeEntityPosition(ped, false);
+	SetPedOnGround();
+	startWeatherResource();
+	DestroyAllCams(true);
+	if (cam) DestroyCam(cam, true);
+	RenderScriptCams(false, false, 0, true, false, 0);
+	camInfo = null;
+	cam = null;
+	clothesJob.running = false;
+	clothesJob.paused = false;
+	clothesJob.stopRequested = false;
+}
+
+// Runs a full capture pass driven by the panel selection.
+//   opts = {
+//     genders:         ['male'] | ['female'] | ['male','female']
+//     components:      { CLOTHING: [int...], PROPS: [int...] }  (component ids)
+//     includeTextures: also iterate every texture of each drawable
+//     skipExisting:    skip items whose PNG already exists (enables resuming)
+//   }
+// It runs in two phases: first a pre-scan that enumerates every item so the
+// total (and therefore the % and ETA) is known up front, then the capture pass.
+async function runClothingJob(opts) {
+	if (clothesJob.running) return;
+	clothesJob.running = true;
+	clothesJob.paused = false;
+	clothesJob.stopRequested = false;
+	clothesJob.times = [];
+	clothesJob.done = 0;
+	clothesJob.total = 0;
+
+	const includeTextures = !!opts.includeTextures;
+	const skipExisting = opts.skipExisting !== false; // defaults to true
+	const existing = lastExisting;
+	const genders = opts.genders && opts.genders.length ? opts.genders : ['male', 'female'];
+	const selected = opts.components || { CLOTHING: [], PROPS: [] };
+
+	if (!stopWeatherResource()) {
+		SendNUIMessage({ action: 'error', error: 'weathersync' });
+		clothesJob.running = false;
+		return;
+	}
+	DisableIdleCamera(true);
+	await Delay(100);
+
+	// --- Pre-scan: enumerate every item across selected genders for an exact total/ETA ---
+	SendNUIMessage({ action: 'progress', done: 0, total: 0, percent: 0, eta: '--:--', rate: '0.00', label: 'Calculating...' });
+	const items = [];
+	for (const gender of genders) {
+		if (clothesJob.stopRequested) break;
+		const p = await loadGenderModel(gender);
+		if (!p) continue;
+		for (const type of ['CLOTHING', 'PROPS']) {
+			const comps = selected[type] || [];
+			for (const component of comps) {
+				if (type === 'CLOTHING') {
+					const dCount = GetNumberOfPedDrawableVariations(ped, component);
+					for (let drawable = 0; drawable < dCount; drawable++) {
+						if (includeTextures) {
+							const tCount = GetNumberOfPedTextureVariations(ped, component, drawable);
+							for (let texture = 0; texture < tCount; texture++) items.push({ gender, pedType: gender, type, component, drawable, texture });
+						} else {
+							items.push({ gender, pedType: gender, type, component, drawable, texture: null });
+						}
+					}
+				} else {
+					const pCount = GetNumberOfPedPropDrawableVariations(ped, component);
+					for (let prop = 0; prop < pCount; prop++) {
+						if (includeTextures) {
+							const tCount = GetNumberOfPedPropTextureVariations(ped, component, prop);
+							for (let texture = 0; texture < tCount; texture++) items.push({ gender, pedType: gender, type, component, drawable: prop, texture });
+						} else {
+							items.push({ gender, pedType: gender, type, component, drawable: prop, texture: null });
+						}
+					}
+				}
+			}
+		}
+	}
+
+	clothesJob.total = items.length;
+	// Items already on disk count as done, so a resumed run's bar starts where
+	// the previous one left off instead of at 0%.
+	if (skipExisting) {
+		clothesJob.done = items.filter((it) => existing.has(clothingFileName(it.pedType, it.type, it.component, it.drawable, it.texture) + '.png')).length;
+	}
+	emitClothesProgress('Starting...');
+
+	// Make sure the world has streamed in around the greenscreen before the first
+	// capture (otherwise the first screenshot can come out completely black): wait
+	// for collision to load, then keep a small fixed delay as an extra buffer.
+	await waitForSceneLoaded(ped);
+	await Delay(config.startupDelay || 1500);
+
+	// --- Capture pass ---
+	let curGender = null;
+	for (const it of items) {
+		// Cooperative stop/pause: checked between items so a stop closes the
+		// current screenshot cleanly rather than aborting mid-write.
+		if (clothesJob.stopRequested) break;
+		await waitWhilePaused();
+		if (clothesJob.stopRequested) break;
+
+		// Only reload the model and reset components when the gender changes,
+		// so items are grouped by gender and we avoid redundant model swaps.
+		if (it.gender !== curGender) {
+			await loadGenderModel(it.gender);
+			curGender = it.gender;
+			if (interval) clearInterval(interval);
+			interval = setInterval(() => ClearPedTasksImmediately(ped), 1);
+			await ResetPedComponents();
+			await Delay(150);
+		}
+
+		const file = clothingFileName(it.pedType, it.type, it.component, it.drawable, it.texture) + '.png';
+		if (skipExisting && existing.has(file)) continue; // already captured
+
+		const t0 = GetGameTimer();
+		const label = `${config.cameraSettings[it.type][it.component].name} ${it.drawable}${it.texture != null ? '/' + it.texture : ''} (${it.gender})`;
+		if (it.type === 'CLOTHING') {
+			await LoadComponentVariation(ped, it.component, it.drawable, it.texture);
+		} else {
+			await LoadPropVariation(ped, it.component, it.drawable, it.texture);
+		}
+		await takeScreenshotForComponent(it.pedType, it.type, it.component, it.drawable, it.texture);
+
+		existing.add(file);
+		clothesJob.done++;
+		clothesJob.times.push(GetGameTimer() - t0);
+		if (clothesJob.times.length > 20) clothesJob.times.shift();
+		emitClothesProgress(label);
+	}
+
+	const wasStopped = clothesJob.stopRequested;
+	cleanupClothesJob();
+	SendNUIMessage({ action: 'done', stopped: wasStopped });
+}
+
+// Opens the panel: grabs NUI focus and hands the NUI the selectable components
+// (built from config so it always matches cameraSettings), then asks the server
+// which images already exist to populate the "skip" baseline.
+RegisterCommand('clothes', () => {
+	SetNuiFocus(true, true);
+	SendNUIMessage({
+		action: 'open',
+		config: {
+			clothing: Object.keys(config.cameraSettings.CLOTHING).map((id) => ({ id: parseInt(id), name: config.cameraSettings.CLOTHING[id].name })),
+			props: Object.keys(config.cameraSettings.PROPS).map((id) => ({ id: parseInt(id), name: config.cameraSettings.PROPS[id].name })),
+		},
+		running: clothesJob.running,
+	});
+	emitNet('greenscreener:requestState');
+}, false);
+
+// Reply from the server with the list of already-captured PNG filenames.
+onNet('greenscreener:state', (data) => {
+	data = data || {};
+	lastExisting = new Set(data.existing || []);
+	SendNUIMessage({ action: 'state', count: (data.existing || []).length });
+});
+
+// Small helper to register a NUI callback and always answer it so the fetch in
+// the NUI resolves.
+function registerNui(name, handler) {
+	RegisterNuiCallbackType(name);
+	on(`__cfx_nui:${name}`, (data, cb) => {
+		try { handler(data || {}); } catch (e) { console.log(`ERROR in NUI callback ${name}: ${e.message}`); }
+		cb('ok');
+	});
+}
+
+// Panel controls. Pause/resume/stop just flip flags on clothesJob; the running
+// capture loop reacts to them on its own.
+registerNui('clothes:start', (data) => {
+	runClothingJob({
+		genders: data.genders,
+		components: data.components,
+		includeTextures: data.includeTextures,
+		skipExisting: data.skipExisting,
+	});
+});
+registerNui('clothes:pause', () => { clothesJob.paused = true; emitClothesProgress(); });
+registerNui('clothes:resume', () => { clothesJob.paused = false; emitClothesProgress(); });
+registerNui('clothes:stop', () => { clothesJob.stopRequested = true; clothesJob.paused = false; });
+registerNui('clothes:close', () => { SetNuiFocus(false, false); });
+
 setImmediate(() => {
 	emit('chat:addSuggestions', [
+		{
+			name: '/clothes',
+			help: 'open the clothing capture control panel (select components, gender, progress, ETA)',
+		},
 		{
 			name: '/screenshot',
 			help: 'generate clothing screenshots',
@@ -778,4 +1122,5 @@ on('onResourceStop', (resName) => {
 	clearInterval(interval);
 	SetPlayerControl(playerId, true);
 	FreezeEntityPosition(ped, false);
+	SetNuiFocus(false, false); // release the cursor if the panel was open
 });

--- a/client.js
+++ b/client.js
@@ -980,6 +980,7 @@ async function runClothingJob(opts) {
 
 	// --- Capture pass ---
 	let curGender = null;
+	let curComponentKey = null;
 	for (const it of items) {
 		// Cooperative stop/pause: checked between items so a stop closes the
 		// current screenshot cleanly rather than aborting mid-write.
@@ -987,15 +988,22 @@ async function runClothingJob(opts) {
 		await waitWhilePaused();
 		if (clothesJob.stopRequested) break;
 
-		// Only reload the model and reset components when the gender changes,
-		// so items are grouped by gender and we avoid redundant model swaps.
+		// Only reload the model when the gender changes (avoids redundant swaps).
 		if (it.gender !== curGender) {
 			await loadGenderModel(it.gender);
 			curGender = it.gender;
+			curComponentKey = null; // force a component reset for the new model
 			if (interval) clearInterval(interval);
 			interval = setInterval(() => ClearPedTasksImmediately(ped), 1);
+		}
+
+		// Reset every component when moving to a new component, so the previous one
+		// (e.g. a mask) doesn't stay on the ped while shooting the next component.
+		const componentKey = `${it.type}:${it.component}`;
+		if (componentKey !== curComponentKey) {
 			await ResetPedComponents();
 			await Delay(150);
+			curComponentKey = componentKey;
 		}
 
 		const file = clothingFileName(it.pedType, it.type, it.component, it.drawable, it.texture) + '.png';

--- a/client.js
+++ b/client.js
@@ -434,7 +434,6 @@ RegisterCommand('screenshot', async (source, args) => {
 			// Wait for the scene to stream in around the greenscreen before the first
 			// capture, otherwise the first screenshot can come out completely black.
 			await waitForSceneLoaded(ped);
-			await Delay(config.startupDelay || 1500);
 
 			interval = setInterval(() => {
 				ClearPedTasksImmediately(ped);
@@ -573,7 +572,6 @@ RegisterCommand('customscreenshot', async (source, args) => {
 			// Wait for the scene to stream in around the greenscreen before the first
 			// capture, otherwise the first screenshot can come out completely black.
 			await waitForSceneLoaded(ped);
-			await Delay(config.startupDelay || 1500);
 
 			ResetPedComponents();
 			await Delay(150);
@@ -710,7 +708,6 @@ RegisterCommand('screenshotobject', async (source, args) => {
 
 	// Wait for the scene to stream in before capturing (avoids a black image).
 	await waitForSceneLoaded(ped);
-	await Delay(config.startupDelay || 1500);
 
 	await takeScreenshotForObject(object, modelHash);
 
@@ -745,7 +742,6 @@ RegisterCommand('screenshotvehicle', async (source, args) => {
 
 	// Wait for the scene to stream in before capturing (avoids black images).
 	await waitForSceneLoaded(ped);
-	await Delay(config.startupDelay || 1500);
 
 	if (type === 'all') {
 		SendNUIMessage({
@@ -978,10 +974,8 @@ async function runClothingJob(opts) {
 	emitClothesProgress('Starting...');
 
 	// Make sure the world has streamed in around the greenscreen before the first
-	// capture (otherwise the first screenshot can come out completely black): wait
-	// for collision to load, then keep a small fixed delay as an extra buffer.
+	// capture, otherwise the first screenshot can come out completely black.
 	await waitForSceneLoaded(ped);
-	await Delay(config.startupDelay || 1500);
 
 	// --- Capture pass ---
 	let curGender = null;

--- a/config.json
+++ b/config.json
@@ -1,5 +1,7 @@
 {
   "debug": false,
+  "startupDelay": 1500,
+  "//__comment__//startupDelay": "Delay in ms before the first screenshot so the world can stream in around the greenscreen, otherwise the first image may come out black.",
   "includeTextures": false,
   "//__comment__//textures": "The image generation will take much longer and you will have much more images!",
   "overwriteExistingImages": true,

--- a/config.json
+++ b/config.json
@@ -1,7 +1,5 @@
 {
   "debug": false,
-  "startupDelay": 1500,
-  "//__comment__//startupDelay": "Delay in ms before the first screenshot so the world can stream in around the greenscreen, otherwise the first image may come out black.",
   "includeTextures": false,
   "//__comment__//textures": "The image generation will take much longer and you will have much more images!",
   "overwriteExistingImages": true,

--- a/html/index.html
+++ b/html/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="es">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/html/index.html
+++ b/html/index.html
@@ -1,17 +1,91 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="es">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css" type="text/css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
     <script src="nui://game/ui/jquery.js" type="text/javascript"></script>
-    <script src="script.js"></script>
-    <title>Progress</title>
+    <title>Greenscreener</title>
 </head>
 <body>
+    <!-- Simple progress overlay for the legacy chat commands (/screenshot, ...) -->
     <div id="container" style="display: none;">
         <p id="text">Progress 0/10 Masks</p>
     </div>
+
+    <!-- /clothes control panel -->
+    <div id="clothes-panel" class="hidden">
+        <header>
+            <span class="dot"></span>
+            <h1>Screenshot Generator</h1>
+            <span class="sub">fivem-greenscreener</span>
+        </header>
+
+        <div class="body">
+            <!-- Gender -->
+            <section class="block">
+                <div class="block-title">Gender</div>
+                <div class="seg" id="gender-seg">
+                    <button class="seg-btn" data-gender="male">Male</button>
+                    <button class="seg-btn active" data-gender="female">Female</button>
+                    <button class="seg-btn" data-gender="both">Both</button>
+                </div>
+            </section>
+
+            <!-- Components -->
+            <section class="block">
+                <div class="block-title">
+                    Components
+                    <button class="link-btn" id="toggle-all">Toggle all</button>
+                </div>
+                <div class="comp-group">
+                    <div class="comp-group-name">Clothing</div>
+                    <div class="comp-list" id="list-clothing"></div>
+                </div>
+                <div class="comp-group">
+                    <div class="comp-group-name">Props</div>
+                    <div class="comp-list" id="list-props"></div>
+                </div>
+            </section>
+
+            <!-- Options -->
+            <section class="block">
+                <div class="block-title">Options</div>
+                <label class="opt"><input type="checkbox" id="opt-textures"><span>Include textures</span></label>
+                <label class="opt"><input type="checkbox" id="opt-skip" checked><span>Skip already captured</span></label>
+            </section>
+
+            <!-- Progress -->
+            <section class="block progress-block">
+                <div class="bar"><div class="bar-fill" id="bar-fill"></div></div>
+                <div class="prog-row">
+                    <span id="prog-counts">0 / 0</span>
+                    <span id="prog-percent">0%</span>
+                </div>
+                <div class="prog-row sub-row">
+                    <span>ETA <b id="prog-eta">--:--</b></span>
+                    <span><b id="prog-rate">0.00</b> img/s</span>
+                </div>
+                <div class="prog-label" id="prog-label">Idle</div>
+            </section>
+
+            <!-- Controls -->
+            <section class="controls">
+                <button class="btn primary" id="btn-start">Start</button>
+                <button class="btn" id="btn-pause" disabled>Pause</button>
+                <button class="btn danger" id="btn-stop" disabled>Stop</button>
+            </section>
+            <section class="controls">
+                <button class="btn ghost" id="btn-close">Close</button>
+            </section>
+            <div class="state-line" id="state-line"></div>
+        </div>
+    </div>
+
+    <script src="script.js"></script>
 </body>
 </html>

--- a/html/script.js
+++ b/html/script.js
@@ -1,43 +1,214 @@
-window.addEventListener('message', function (event) {
-  var data = event.data
+// ============================================================================
+//  fivem-greenscreener NUI
+//  - Classic progress overlay (/screenshot, /customscreenshot, ... commands)
+//  - /clothes control panel (selection, progress, ETA, pause/resume/stop)
+// ============================================================================
 
-  if (data.hasOwnProperty('type')) {
-    var type = data.type
-    var drawable = data.value
-    var max = data.max
-    const text = this.document.getElementById('text')
+const RES = 'fivem-greenscreener'; // must match the resource folder name
 
-    text.innerHTML = `${drawable}/${max} ${type}`
-  }
-  if (data.hasOwnProperty('start')) {
-    const text = this.document.getElementById('text')
-    const container = this.document.getElementById('container')
-    text.innerHTML = 'Loading up ...'
-    container.style.display = 'block'
-  }
-  if (data.hasOwnProperty('end')) {
-    const text = this.document.getElementById('text')
-    const container = this.document.getElementById('container')
-    text.innerHTML = 'Finished!'
-    this.setTimeout(() => {
-      container.style.display = 'none'
-    }, 2000)
-  }
-  if (data.hasOwnProperty('error')) {
-    var type = data.error
-    const text = this.document.getElementById('text')
-    const container = this.document.getElementById('container')
+// POSTs a NUI callback to the client script (RegisterNuiCallbackType).
+function post(name, data) {
+    return fetch(`https://${RES}/${name}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json; charset=UTF-8' },
+        body: JSON.stringify(data || {}),
+    }).catch(() => {});
+}
 
-    if (type == 'weathersync') {
-      text.innerHTML = 'Disable weathersync resource!'
-      this.setTimeout(() => {
-        container.style.display = 'none'
-      }, 2000)
-    } else {
-      text.innerHTML = 'Error!'
-      this.setTimeout(() => {
-        container.style.display = 'none'
-      }, 2000)
+const $ = (id) => document.getElementById(id);
+
+// --- Panel state ------------------------------------------------------------
+let activeGender = 'female'; // 'male' | 'female' | 'both'
+let isRunning = false;
+let isPaused = false;
+let isStopping = false; // stop requested, waiting for the job to actually finish
+
+const panel = $('clothes-panel');
+
+// Builds the selectable component chips from the config sent by the client.
+// Chips start selected; clicking toggles them (locked while a run is active).
+function renderChips(listEl, items) {
+    listEl.innerHTML = '';
+    (items || []).forEach((it) => {
+        const chip = document.createElement('div');
+        chip.className = 'chip on';
+        chip.dataset.id = it.id;
+        chip.textContent = it.name || it.id;
+        chip.addEventListener('click', () => {
+            if (isRunning) return;
+            chip.classList.toggle('on');
+        });
+        listEl.appendChild(chip);
+    });
+}
+
+// Reads the currently selected component ids, split into clothing and props.
+function collectComponents() {
+    const grab = (sel) => Array.from(document.querySelectorAll(`${sel} .chip.on`)).map((c) => parseInt(c.dataset.id));
+    return { CLOTHING: grab('#list-clothing'), PROPS: grab('#list-props') };
+}
+
+function setGender(g) {
+    activeGender = g;
+    document.querySelectorAll('#gender-seg .seg-btn').forEach((b) => {
+        b.classList.toggle('active', b.dataset.gender === g);
+    });
+}
+
+function gendersArray() {
+    return activeGender === 'both' ? ['male', 'female'] : [activeGender];
+}
+
+// Toggles the panel between idle and running: while running the selection is
+// locked and only pause/stop are usable.
+function setRunning(running) {
+    isRunning = running;
+    $('btn-start').disabled = running;
+    $('btn-pause').disabled = !running;
+    $('btn-stop').disabled = !running;
+    $('btn-close').disabled = false;
+    // lock selection while running
+    document.querySelectorAll('#gender-seg .seg-btn, #toggle-all').forEach((b) => (b.disabled = running));
+    document.querySelectorAll('.opt input').forEach((i) => (i.disabled = running));
+    if (!running) {
+        isPaused = false;
+        isStopping = false;
+        $('btn-pause').textContent = 'Pause';
     }
-  }
-})
+}
+
+// Disables every control while a stop is in flight, until the job reports done.
+function setStopping() {
+    isStopping = true;
+    $('btn-start').disabled = true;
+    $('btn-pause').disabled = true;
+    $('btn-stop').disabled = true;
+    $('btn-close').disabled = true;
+    $('prog-label').textContent = 'Stopping...';
+}
+
+// Renders a progress snapshot from the client onto the bar, counters and ETA.
+function updateProgress(d) {
+    $('bar-fill').style.width = (d.percent || 0) + '%';
+    $('prog-counts').textContent = `${d.done || 0} / ${d.total || 0}`;
+    $('prog-percent').textContent = (d.percent || 0) + '%';
+    $('prog-eta').textContent = d.eta || '--:--';
+    $('prog-rate').textContent = d.rate || '0.00';
+    // keep showing "Stopping..." while the job winds down
+    if (d.label && !isStopping) $('prog-label').textContent = d.label;
+    isPaused = !!d.paused;
+    if (!isStopping) $('btn-pause').textContent = isPaused ? 'Resume' : 'Pause';
+}
+
+// --- Buttons ----------------------------------------------------------------
+document.querySelectorAll('#gender-seg .seg-btn').forEach((b) => {
+    b.addEventListener('click', () => { if (!isRunning) setGender(b.dataset.gender); });
+});
+
+$('toggle-all').addEventListener('click', () => {
+    if (isRunning) return;
+    const chips = document.querySelectorAll('#clothes-panel .chip');
+    const anyOff = Array.from(chips).some((c) => !c.classList.contains('on'));
+    chips.forEach((c) => c.classList.toggle('on', anyOff));
+});
+
+$('btn-start').addEventListener('click', () => {
+    const components = collectComponents();
+    if (!components.CLOTHING.length && !components.PROPS.length) {
+        $('prog-label').textContent = 'Select at least one component';
+        return;
+    }
+    setRunning(true);
+    $('prog-label').textContent = 'Calculating...';
+    post('clothes:start', {
+        genders: gendersArray(),
+        components,
+        includeTextures: $('opt-textures').checked,
+        skipExisting: $('opt-skip').checked,
+    });
+});
+
+$('btn-pause').addEventListener('click', () => {
+    if (!isRunning) return;
+    if (isPaused) { post('clothes:resume'); isPaused = false; $('btn-pause').textContent = 'Pause'; }
+    else { post('clothes:pause'); isPaused = true; $('btn-pause').textContent = 'Resume'; }
+});
+
+// Stop is asynchronous: the current screenshot must finish first, so we lock
+// the controls and wait for the 'done' message before re-enabling them.
+$('btn-stop').addEventListener('click', () => {
+    if (!isRunning || isStopping) return;
+    setStopping();
+    post('clothes:stop');
+});
+
+function closePanel() {
+    if (isStopping) return;
+    panel.classList.add('hidden');
+    post('clothes:close');
+}
+$('btn-close').addEventListener('click', closePanel);
+
+document.addEventListener('keyup', (e) => {
+    if (e.key === 'Escape' && !panel.classList.contains('hidden') && !isRunning) closePanel();
+});
+
+// --- Messages from Lua ------------------------------------------------------
+window.addEventListener('message', (event) => {
+    const data = event.data || {};
+
+    // ----- Panel /clothes -----
+    if (data.action === 'open') {
+        if (data.config) {
+            renderChips($('list-clothing'), data.config.clothing);
+            renderChips($('list-props'), data.config.props);
+        }
+        setRunning(!!data.running);
+        if (!data.running) updateProgress({ done: 0, total: 0, percent: 0, eta: '--:--', rate: '0.00' });
+        panel.classList.remove('hidden');
+        return;
+    }
+    if (data.action === 'progress') {
+        // Don't re-enable controls if a stop is in flight (progress can still
+        // arrive for the screenshot that is finishing up).
+        if (!isStopping) setRunning(true);
+        updateProgress(data);
+        return;
+    }
+    if (data.action === 'done') {
+        setRunning(false);
+        $('prog-label').textContent = data.stopped ? 'Stopped' : 'Finished';
+        return;
+    }
+    if (data.action === 'state') {
+        // How many images already exist on disk (informational).
+        $('state-line').textContent = `${data.count || 0} images on disk`;
+        return;
+    }
+    if (data.action === 'error') {
+        setRunning(false);
+        $('prog-label').textContent = data.error === 'weathersync' ? 'Disable the weathersync resource!' : 'Error';
+        return;
+    }
+
+    // ----- Classic overlay (legacy chat commands) -----
+    if (data.hasOwnProperty('type')) {
+        $('text').innerHTML = `${data.value}/${data.max} ${data.type}`;
+        return;
+    }
+    if (data.hasOwnProperty('start')) {
+        $('text').innerHTML = 'Loading up ...';
+        $('container').style.display = 'block';
+        return;
+    }
+    if (data.hasOwnProperty('end')) {
+        $('text').innerHTML = 'Finished!';
+        setTimeout(() => { $('container').style.display = 'none'; }, 2000);
+        return;
+    }
+    if (data.hasOwnProperty('error')) {
+        $('text').innerHTML = data.error === 'weathersync' ? 'Disable weathersync resource!' : 'Error!';
+        $('container').style.display = 'block';
+        setTimeout(() => { $('container').style.display = 'none'; }, 2000);
+    }
+});

--- a/html/style.css
+++ b/html/style.css
@@ -1,22 +1,201 @@
-@import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@300&display=swap');
+* { margin: 0; padding: 0; box-sizing: border-box; }
 
+html, body {
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    background: transparent;
+    font-family: 'Roboto', 'Segoe UI', system-ui, sans-serif;
+    user-select: none;
+}
+
+.hidden { display: none !important; }
+
+/* ===== Classic progress overlay (/screenshot, ... commands) =============== */
 #container {
     margin: 0;
     position: absolute;
     bottom: 10%;
     left: 50%;
     transform: translate(-50%, -50%);
-    background-color: rgba(0, 0, 0, 0.385);
-    width: 20%;
-    height: 5%;
+    background-color: rgba(0, 0, 0, 0.5);
+    width: 22%;
     text-align: center;
     border-radius: 10px;
-    border: 2px solid rgb(0, 0, 0);
+    border: 2px solid rgba(61, 220, 132, 0.5);
+}
+#container p {
+    color: #fff;
+    font-size: 1.3em;
+    margin: 3%;
+    font-family: 'Roboto', sans-serif;
 }
 
-#container p {
-    color: white;
-    font-size: 1.5em;
-    margin: 3%;
-    font-family: 'Open Sans', sans-serif;
+/* ===== Panel /clothes ===================================================== */
+:root {
+    --accent: #3ddc84;
+    --accent-soft: rgba(61, 220, 132, 0.16);
+    --danger: #f0635c;
+}
+
+#clothes-panel {
+    position: absolute;
+    top: 50%;
+    right: 26px;
+    transform: translateY(-50%);
+    width: 320px;
+    max-height: 92vh;
+    display: flex;
+    flex-direction: column;
+    background: linear-gradient(180deg, rgba(18, 22, 27, 0.94) 0%, rgba(10, 12, 15, 0.97) 100%);
+    border: 1px solid rgba(255, 255, 255, 0.10);
+    border-radius: 14px;
+    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.6), inset 0 1px 0 rgba(255, 255, 255, 0.05);
+    color: #eef1f3;
+    overflow: hidden;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+}
+
+/* Header */
+#clothes-panel header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 13px 15px 11px;
+    background: linear-gradient(90deg, var(--accent-soft), rgba(61, 220, 132, 0));
+    border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+    flex: 0 0 auto;
+}
+#clothes-panel header .dot {
+    width: 9px; height: 9px; border-radius: 50%;
+    background: var(--accent);
+    box-shadow: 0 0 10px var(--accent);
+}
+#clothes-panel header h1 {
+    font-family: 'Roboto', sans-serif;
+    font-size: 15px; font-weight: 500; letter-spacing: .3px;
+}
+#clothes-panel header .sub {
+    margin-left: auto; font-size: 8.5px; opacity: .4;
+    text-transform: uppercase; letter-spacing: 1px;
+}
+
+/* Body scrollable */
+.body {
+    padding: 12px 14px 14px;
+    overflow-y: auto;
+    flex: 1 1 auto;
+}
+.body::-webkit-scrollbar { width: 7px; }
+.body::-webkit-scrollbar-thumb { background: rgba(255,255,255,.12); border-radius: 4px; }
+
+.block { margin-bottom: 14px; }
+.block-title {
+    display: flex; align-items: center; justify-content: space-between;
+    font-size: 10px; text-transform: uppercase; letter-spacing: 1.2px;
+    opacity: .55; margin-bottom: 8px;
+}
+.link-btn {
+    background: none; border: none; cursor: pointer;
+    color: var(--accent); font-family: inherit; font-size: 9.5px;
+    text-transform: uppercase; letter-spacing: .6px; opacity: .85;
+}
+.link-btn:hover { opacity: 1; }
+
+/* Segmented (gender) */
+.seg { display: flex; gap: 6px; }
+.seg-btn {
+    flex: 1; padding: 8px 0; cursor: pointer;
+    background: rgba(255,255,255,.05);
+    border: 1px solid rgba(255,255,255,.10);
+    border-radius: 8px; color: #cfd3d6;
+    font-family: inherit; font-size: 11.5px; font-weight: 500;
+    transition: all .12s ease;
+}
+.seg-btn:hover { background: rgba(255,255,255,.09); }
+.seg-btn.active {
+    background: var(--accent-soft);
+    border-color: var(--accent);
+    color: #d8ffe8;
+    box-shadow: inset 0 0 0 1px rgba(61,220,132,.3);
+}
+
+/* Components */
+.comp-group { margin-bottom: 8px; }
+.comp-group-name {
+    font-size: 10px; opacity: .5; margin: 4px 2px 5px;
+    font-weight: 700; letter-spacing: .4px;
+}
+.comp-list { display: flex; flex-wrap: wrap; gap: 5px; }
+.chip {
+    display: inline-flex; align-items: center;
+    padding: 5px 10px; cursor: pointer;
+    background: rgba(255,255,255,.05);
+    border: 1px solid rgba(255,255,255,.10);
+    border-radius: 20px; font-size: 11px; color: #c7cbce;
+    transition: all .1s ease;
+}
+.chip:hover { background: rgba(255,255,255,.09); }
+.chip.on {
+    background: var(--accent-soft);
+    border-color: var(--accent);
+    color: #d8ffe8;
+}
+
+/* Options */
+.opt {
+    display: flex; align-items: center; gap: 8px;
+    padding: 5px 2px; font-size: 12px; cursor: pointer; opacity: .9;
+}
+.opt input { accent-color: var(--accent); width: 15px; height: 15px; cursor: pointer; }
+
+/* Progress */
+.progress-block { margin-top: 4px; }
+.bar {
+    height: 10px; border-radius: 6px; overflow: hidden;
+    background: rgba(255,255,255,.08);
+    border: 1px solid rgba(255,255,255,.08);
+}
+.bar-fill {
+    height: 100%; width: 0%;
+    background: linear-gradient(90deg, #2fae66, var(--accent));
+    box-shadow: 0 0 10px rgba(61,220,132,.5);
+    transition: width .25s ease;
+}
+.prog-row {
+    display: flex; justify-content: space-between;
+    margin-top: 7px; font-size: 13px; font-weight: 700;
+    font-variant-numeric: tabular-nums;
+}
+.prog-row.sub-row { font-size: 11px; font-weight: 400; opacity: .7; margin-top: 4px; }
+.prog-row b { color: var(--accent); font-weight: 700; }
+.prog-label {
+    margin-top: 7px; font-size: 10.5px; opacity: .6;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+
+/* Controls */
+.controls { display: flex; gap: 7px; margin-top: 4px; }
+.controls + .controls { margin-top: 7px; }
+.btn {
+    flex: 1; padding: 9px 0; cursor: pointer;
+    background: rgba(255,255,255,.06);
+    border: 1px solid rgba(255,255,255,.12);
+    border-radius: 8px; color: #e7eaec;
+    font-family: inherit; font-size: 11.5px; font-weight: 500;
+    transition: all .12s ease;
+}
+.btn:hover:not(:disabled) { background: rgba(255,255,255,.11); }
+.btn:disabled { opacity: .35; cursor: not-allowed; }
+.btn.primary {
+    background: var(--accent-soft); border-color: var(--accent); color: #d8ffe8;
+}
+.btn.primary:hover:not(:disabled) { background: rgba(61,220,132,.26); }
+.btn.danger { color: #ffb3af; border-color: rgba(240,99,92,.35); }
+.btn.danger:hover:not(:disabled) { background: rgba(240,99,92,.16); }
+.btn.ghost { font-size: 10.5px; opacity: .85; }
+
+.state-line {
+    margin-top: 10px; font-size: 10px; opacity: .5; text-align: center;
+    min-height: 12px;
 }

--- a/server.js
+++ b/server.js
@@ -36,10 +36,11 @@ try {
 		}
 
 		// Note: we intentionally do NOT pass `fileName` to screenshot-basic.
-		// Doing so would make screenshot-basic move the file into this resource's
-		// folder, which trips FiveM's cross-resource fs.write permission check.
-		// Instead we request the screenshot as a base64 data URI and write it
-		// ourselves, since a resource is always allowed to write to its own folder.
+		// With a fileName set, screenshot-basic moves the staged upload into this
+		// resource's folder, which trips FiveM's cross-resource fs.write permission
+		// check on recent FXServer builds. Instead we request the screenshot as a
+		// base64 data URI and write it ourselves, since a resource is always allowed
+		// to write to its own folder.
 		exports['screenshot-basic'].requestClientScreenshot(
 			source,
 			{

--- a/server.js
+++ b/server.js
@@ -36,11 +36,10 @@ try {
 		}
 
 		// Note: we intentionally do NOT pass `fileName` to screenshot-basic.
-		// With a fileName set, screenshot-basic moves the staged upload into this
-		// resource's folder, which trips FiveM's cross-resource fs.write permission
-		// check on recent FXServer builds. Instead we request the screenshot as a
-		// base64 data URI and write it ourselves, since a resource is always allowed
-		// to write to its own folder.
+		// Doing so would make screenshot-basic move the file into this resource's
+		// folder, which trips FiveM's cross-resource fs.write permission check.
+		// Instead we request the screenshot as a base64 data URI and write it
+		// ourselves, since a resource is always allowed to write to its own folder.
 		exports['screenshot-basic'].requestClientScreenshot(
 			source,
 			{
@@ -110,6 +109,26 @@ try {
 				image.save(fullFilePath);
 			}
 		);
+	});
+
+	// --- /clothes panel support ------------------------------------------------
+	// Clothing and props are both written into images/clothing.
+	const clothingPath = `${mainSavePath}/clothing`;
+
+	// Returns the PNG filenames already on disk so the panel can show how many
+	// are done and skip them when resuming a run. The client matches these names
+	// against the ones it is about to capture.
+	onNet('greenscreener:requestState', () => {
+		const src = source; // capture before any await/emit
+		let existing = [];
+		try {
+			if (fs.existsSync(clothingPath)) {
+				existing = fs.readdirSync(clothingPath).filter((f) => f.toLowerCase().endsWith('.png'));
+			}
+		} catch (e) {
+			console.error(`greenscreener: error reading state: ${e.message}`);
+		}
+		emitNet('greenscreener:state', src, { existing });
 	});
 } catch (error) {
 	console.error(error.message);


### PR DESCRIPTION
## Summary

This PR adds an optional **`/customclothes` control panel** for clothing/prop capture and a few capture-quality fixes. Everything is additive — the existing chat commands (`/screenshot`, `/customscreenshot`, `/screenshotobject`, `/screenshotvehicle`) keep working exactly as before.

## Screenshot

<img width="1919" height="1079" alt="Captura de pantalla 2026-06-29 202116" src="https://github.com/user-attachments/assets/8061b78b-2d7d-4bef-8638-0108215ab6b8" />


## What's included

### 1. `/customclothes` NUI control panel
A side panel (opened with `/customclothes`) to drive clothing/prop generation without typing commands:
- Pick **components** (clothing + props, built from `config.cameraSettings`) and **gender** (male / female / both).
- **Start / Pause / Resume / Stop** an in-progress run.
- Live **progress bar with ETA** and images/sec, based on a rolling average.
- **Skip already captured**: the server lists the PNGs already on disk, so a long run can be resumed just by launching it again.

It reuses the existing capture helpers (`takeScreenshotForComponent`, `LoadComponentVariation`, …) and shares the legacy progress overlay markup.

### 2. Hide the native HUD during capture
Some HUD elements (radar/minimap, area/street/vehicle names, notifications, wanted stars…) were getting baked into screenshots. Now the whole native HUD is hidden every frame while capturing, hooked into the existing `stopWeatherResource` / `startWeatherResource` start/end points, so it covers **all** capture flows and restores afterwards.

### 3. Wait for the scene before the first capture
The first image could come out blank/black while the world was still streaming in around the greenscreen. Before the first capture each flow now waits for collision to load around the ped (`HasCollisionLoadedAroundEntity`, with a 5s timeout).

## Testing
Tested on Windows, FXServer b31550, with both the panel and the classic commands:
- Panel start/pause/resume/stop, progress + ETA, and skip/resume all work.
- No HUD/minimap/zone-name leaks into the images.
- Classic commands unchanged.
